### PR TITLE
feat(search): allow search manager injection

### DIFF
--- a/Orcar/search_agent.py
+++ b/Orcar/search_agent.py
@@ -8,7 +8,7 @@ import os
 import traceback
 import uuid
 from queue import PriorityQueue
-from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 from llama_index.core.agent.runner.base import AgentRunner
 from llama_index.core.agent.types import BaseAgentWorker, Task, TaskStep, TaskStepOutput
@@ -1471,11 +1471,22 @@ class SearchAgent(AgentRunner):
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
         config_path: str = "search.cfg",
+        search_manager: Optional[Any] = None,
+        search_manager_factory: Optional[Callable[[str], Any]] = None,
     ) -> None:
         """Init params."""
         callback_manager = callback_manager or llm.callback_manager
 
-        self._search_manager = SearchManager(repo_path=repo_path)
+        if search_manager is not None and search_manager_factory is not None:
+            raise ValueError(
+                "Cannot specify both search_manager and search_manager_factory"
+            )
+        if search_manager is not None:
+            self._search_manager = search_manager
+        elif search_manager_factory is not None:
+            self._search_manager = search_manager_factory(repo_path)
+        else:
+            self._search_manager = SearchManager(repo_path=repo_path)
         self._tools = self._setup_tools()
 
         step_engine = SearchWorker.from_tools(

--- a/tests/test_search_manager_injection.py
+++ b/tests/test_search_manager_injection.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from Orcar.search_agent import SearchAgent, SearchWorker
+
+
+@pytest.fixture()
+def llm():
+    return SimpleNamespace(callback_manager=None)
+
+
+@patch("Orcar.search_agent.AgentRunner.__init__", return_value=None)
+@patch.object(SearchWorker, "from_tools", return_value=object())
+@patch.object(SearchAgent, "_setup_tools", return_value=[])
+def test_search_agent_accepts_injected_manager(
+    _setup_tools,
+    _from_tools,
+    _runner_init,
+    llm,
+):
+    manager = object()
+
+    agent = SearchAgent(llm=llm, repo_path="/repo", search_manager=manager)
+
+    assert agent._search_manager is manager
+    _from_tools.assert_called_once()
+
+
+@patch("Orcar.search_agent.AgentRunner.__init__", return_value=None)
+@patch.object(SearchWorker, "from_tools", return_value=object())
+@patch.object(SearchAgent, "_setup_tools", return_value=[])
+def test_search_agent_accepts_manager_factory(
+    _setup_tools,
+    _from_tools,
+    _runner_init,
+    llm,
+):
+    manager = object()
+    factory = Mock(return_value=manager)
+
+    agent = SearchAgent(
+        llm=llm,
+        repo_path="/repo",
+        search_manager_factory=factory,
+    )
+
+    assert agent._search_manager is manager
+    factory.assert_called_once_with("/repo")
+
+
+def test_search_agent_rejects_manager_and_factory(llm):
+    with pytest.raises(
+        ValueError,
+        match="both search_manager and search_manager_factory",
+    ):
+        SearchAgent(
+            llm=llm,
+            search_manager=object(),
+            search_manager_factory=Mock(),
+        )


### PR DESCRIPTION
## Summary

Allow `SearchAgent` to consume an externally managed repository search
provider while preserving the existing `SearchManager(repo_path)` default.

## Changes

- accept either `search_manager` or `search_manager_factory`
- reject ambiguous calls that provide both
- keep tool wrapping, `SearchWorker`, prompts, queueing, scoring, and output logic unchanged
- cover direct injection, factory injection, and invalid configuration

## Testing

- `python -m pytest -q tests/test_search_manager_injection.py --tb=short` (3 passed)